### PR TITLE
Geometry tests 2

### DIFF
--- a/allfed_spatial/geometry/line.py
+++ b/allfed_spatial/geometry/line.py
@@ -59,8 +59,10 @@ def frechet_distance(points1, points2):
         line2NextSegLength = line2Seg.length + line2PrevSegLength
 
         if ((line1NextSegLength / line1Len) < (line2NextSegLength / line2Len)):
+            line2DistFromLine1 = (line2Len * line1NextSegLength / line1Len)
+            line2DistanceToImplicit = line2DistFromLine1 - line2PrevSegLength
             line2Implicit = line2Seg.interpolate(
-                (line2Len * line1NextSegLength / line1Len) - line2PrevSegLength,
+                max(line2DistanceToImplicit, 0),
                 normalized = False)
             maxDist = max(
                 maxDist,
@@ -68,8 +70,10 @@ def frechet_distance(points1, points2):
             line1PointIndex += 1
             line1PrevSegLength = line1NextSegLength
         else:
+            line1DistFromLine2 = (line1Len * line2NextSegLength / line2Len)
+            line1DistanceToImplicit = line1DistFromLine2 - line1PrevSegLength
             line1Implicit = line1Seg.interpolate(
-                (line1Len * line2NextSegLength / line2Len) - line1PrevSegLength,
+                max(line1DistanceToImplicit, 0),
                 normalized = False)
             maxDist = max(
                 maxDist,

--- a/allfed_spatial/geometry/merge.py
+++ b/allfed_spatial/geometry/merge.py
@@ -7,6 +7,12 @@ def merge_features(features):
     """ Merge feature geometries together where possible, forming several
     contiguous MultiLineStrings. Applies data of first feature to all.
 
+    Note:
+    - ordering of loops seems to be somewhat arbitary
+    - ordering of crossing loops is unpredictable
+    - touching loops don't seem to join
+    avoid loops if feasible.
+
     Arguments:
         features {list} -- list of Features
     """

--- a/allfed_spatial/geometry/merge.py
+++ b/allfed_spatial/geometry/merge.py
@@ -10,6 +10,10 @@ def merge_features(features):
     Arguments:
         features {list} -- list of Features
     """
+
+    if (features == None or len(features) < 1):
+        raise ValueError('List of features needs at least 1 member')
+
     merged_features = []
     merged_geoms = linemerge([f.geom for f in features])
 

--- a/tests/test_geometry_merge.py
+++ b/tests/test_geometry_merge.py
@@ -1,6 +1,6 @@
 import unittest
 from shapely.ops import linemerge
-from shapely.geometry import LineString
+from shapely.geometry import LineString, MultiLineString
 import allfed_spatial.geometry.merge as geometry_merge
 from allfed_spatial.features.feature import Feature
 from tests.test_geometry_line import LineBaseTest
@@ -52,6 +52,114 @@ class Test_linemerge(LineBaseTest):
                 LineString([(1, 1.000001), (2, 2), (3, 3)])
             ])
 
+    def test_connect_non_adjacent_lines(self):
+        line1 = LineString([(0, 0), (1, 1)])
+        line2 = LineString([(2, 2), (3, 3)])
+        line3 = LineString([(1, 1), (2, 2)])
+        result = linemerge([line1, line2, line3])
+        self.assertEqual(result.geom_type, 'LineString')
+        self.LineEquivalent(
+            result,
+            LineString([(0, 0), (1, 1), (2, 2), (3, 3)]))
+
+    def test_connect_triangle(self):
+        """ It seems that loops start at an arbitary index,
+        we should avoid these where possible """
+        line1 = LineString([(0, 0), (1, 1)])
+        line2 = LineString([(1, 1), (0, 1)])
+        line3 = LineString([(0, 1), (0, 0)])
+        result = linemerge([line1, line2, line3])
+        self.assertEqual(result.geom_type, 'LineString')
+        self.LineEquivalent(
+            result,
+            LineString([(0, 0), (1, 1), (0, 1), (0, 0)]))
+
+    def test_connect_crossing(self):
+        """ It seems that crossing loops start unpredictably,
+        we should avoid these where possible """
+        line1 = LineString([(0, 0), (0, 1), (1, 1)])
+        line2 = LineString([(1, 1), (2, 1), (2, 2)])
+        line3 = LineString([(2, 2), (1, 2), (1, 1)])
+        line4 = LineString([(1, 1), (1, 0), (0, 0)])
+        result = linemerge([line1, line2, line3, line4])
+
+        expected = LineString([
+            (0, 0),
+            (0, 1),
+            (1, 1),
+            (2, 1),
+            (2, 2),
+            (1, 2),
+            (1, 1),
+            (1, 0),
+            (0, 0)
+        ])
+
+        shapelyReality = MultiLineString([
+            LineString([
+                (1, 1),
+                (2, 1),
+                (2, 2),
+                (1, 2),
+                (1, 1)
+            ]),
+            LineString([
+                (1, 1),
+                (1, 0),
+                (0, 0),
+                (0, 1),
+                (1, 1)
+            ])
+        ])
+
+        #self.assertEqual(result.geom_type, 'LineString')
+        self.assertEqual(result.geom_type, 'MultiLineString')
+        self.LinesEquivalent(
+            result,
+            shapelyReality)
+
+    def test_merge_loops(self):
+        """ It seems that loops won't merge,
+        we should avoid these where possible """
+        line1 = LineString([(1, 1), (2, 1), (2, 2), (1, 2), (1, 1)])
+        line2 = LineString([(1, 1), (1, 0), (0, 0), (0, 1), (1, 1)])
+        result = linemerge([line1, line2])
+
+        expected = LineString([
+            (1, 1),
+            (2, 1),
+            (2, 2),
+            (1, 2),
+            (1, 1),
+            (1, 0),
+            (0, 0),
+            (0, 1),
+            (1, 1),
+        ])
+
+        shapelyReality = MultiLineString([
+            LineString([
+                (1, 1),
+                (2, 1),
+                (2, 2),
+                (1, 2),
+                (1, 1)
+            ]),
+            LineString([
+                (1, 1),
+                (1, 0),
+                (0, 0),
+                (0, 1),
+                (1, 1)
+            ])
+        ])
+
+        #self.assertEqual(result.geom_type, 'LineString')
+        self.assertEqual(result.geom_type, 'MultiLineString')
+        self.LinesEquivalent(
+            result,
+            shapelyReality)
+
 class Test_merge_features(LineBaseTest):
     def test_no_features(self):
         with self.assertRaises(ValueError):
@@ -96,6 +204,18 @@ class Test_merge_features(LineBaseTest):
         self.FeaturesEqual(result, [
             feature1,
             Feature(LineString([(1, 1.000001), (2, 2), (3, 3)]), f1data)
+        ])
+
+    def test_three_non_adjacent_features_merge(self):
+        f1data = {'feature': 1, 'test 1': 'data 23'}
+        f2data = {'feature': 2, 'test 2': 'data 34'}
+        f3data = {'feature': 3, 'test 3': 'data 45'}
+        feature1 = Feature(LineString([(0, 0), (1, 1)]), f1data)
+        feature2 = Feature(LineString([(2, 2), (3, 3)]), f2data)
+        feature3 = Feature(LineString([(1, 1), (2, 2)]), f3data)
+        result = geometry_merge.merge_features([feature1, feature2, feature3])
+        self.FeaturesEqual(result, [
+            Feature(LineString([(0, 0), (1, 1), (2, 2), (3, 3)]), f1data)
         ])
 
 if __name__ == '__main__':

--- a/tests/test_geometry_merge.py
+++ b/tests/test_geometry_merge.py
@@ -1,0 +1,56 @@
+import unittest
+from shapely.ops import linemerge
+from shapely.geometry import LineString
+import allfed_spatial.geometry.merge as geometry_merge
+from allfed_spatial.features.feature import Feature
+from tests.test_geometry_line import LineBaseTest
+
+class Test_linemerge(LineBaseTest):
+    """ Confirm the usage of linemerge """
+
+    def test_2_connected_lines(self):
+        line1 = LineString([(0, 0), (1, 1)])
+        line2 = LineString([(1, 1), (2, 2)])
+        result = linemerge([line1, line2])
+        self.assertEqual(result.geom_type, 'LineString')
+        self.LineEquivalent(
+            result,
+            LineString([(0, 0), (1, 1), (2, 2)]))
+
+    def test_3_connected_lines(self):
+        line1 = LineString([(0, 0), (1, 1)])
+        line2 = LineString([(1, 1), (2, 2)])
+        line3 = LineString([(2, 2), (3, 3)])
+        result = linemerge([line1, line2, line3])
+        self.assertEqual(result.geom_type, 'LineString')
+        self.LineEquivalent(
+            result,
+            LineString([(0, 0), (1, 1), (2, 2), (3, 3)]))
+
+    def test_2_disconnected_lines(self):
+        line1 = LineString([(0, 0), (1, 1)])
+        line2 = LineString([(1, 1.000001), (2, 2)])
+        result = linemerge([line1, line2])
+        self.assertEqual(result.geom_type, 'MultiLineString')
+        self.LinesEquivalent(
+            result,
+            [
+                LineString([(0, 0), (1, 1)]),
+                LineString([(1, 1.000001), (2, 2)])
+            ])
+
+    def test_disconnect_and_connect_lines(self):
+        line1 = LineString([(0, 0), (1, 1)])
+        line2 = LineString([(1, 1.000001), (2, 2)])
+        line3 = LineString([(2, 2), (3, 3)])
+        result = linemerge([line1, line2, line3])
+        self.assertEqual(result.geom_type, 'MultiLineString')
+        self.LinesEquivalent(
+            result,
+            [
+                LineString([(0, 0), (1, 1)]),
+                LineString([(1, 1.000001), (2, 2), (3, 3)])
+            ])
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_geometry_merge.py
+++ b/tests/test_geometry_merge.py
@@ -52,5 +52,51 @@ class Test_linemerge(LineBaseTest):
                 LineString([(1, 1.000001), (2, 2), (3, 3)])
             ])
 
+class Test_merge_features(LineBaseTest):
+    def test_no_features(self):
+        with self.assertRaises(ValueError):
+            geometry_merge.merge_features([])
+
+    def test_one_feature(self):
+        feature1 = Feature(
+            LineString([(0, 0), (1, 1)]),
+            {'feature': 1, 'test 1': 'data 23'})
+        result = geometry_merge.merge_features([feature1])
+        self.FeaturesEqual(result, [feature1])
+
+    def test_two_features_merge(self):
+        f1data = {'feature': 1, 'test 1': 'data 23'}
+        f2data = {'feature': 2, 'test 2': 'data 34'}
+        feature1 = Feature(LineString([(0, 0), (1, 1)]), f1data)
+        feature2 = Feature(LineString([(1, 1), (2, 2)]), f2data)
+        result = geometry_merge.merge_features([feature1, feature2])
+        self.FeaturesEqual(result, [
+            Feature(LineString([(0, 0), (1, 1), (2, 2)]), f1data)
+        ])
+
+    def test_two_features_dont_merge(self):
+        f1data = {'feature': 1, 'test 1': 'data 23'}
+        f2data = {'feature': 2, 'test 2': 'data 34'}
+        feature1 = Feature(LineString([(0, 0), (1, 1)]), f1data)
+        feature2 = Feature(LineString([(1, 1.000001), (2, 2)]), f2data)
+        result = geometry_merge.merge_features([feature1, feature2])
+        self.FeaturesEqual(result, [
+            feature1,
+            Feature(LineString([(1, 1.000001), (2, 2)]), f1data)
+        ])
+
+    def test_three_features_merge_and_dont_merge(self):
+        f1data = {'feature': 1, 'test 1': 'data 23'}
+        f2data = {'feature': 2, 'test 2': 'data 34'}
+        f3data = {'feature': 3, 'test 3': 'data 45'}
+        feature1 = Feature(LineString([(0, 0), (1, 1)]), f1data)
+        feature2 = Feature(LineString([(1, 1.000001), (2, 2)]), f2data)
+        feature3 = Feature(LineString([(2, 2), (3, 3)]), f3data)
+        result = geometry_merge.merge_features([feature1, feature2, feature3])
+        self.FeaturesEqual(result, [
+            feature1,
+            Feature(LineString([(1, 1.000001), (2, 2), (3, 3)]), f1data)
+        ])
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Testing geometry/merge.py
Also fixing edge cases and updating docs

When merging loops: I expected sequential handling, or failing, instead my best hypothesis is that it seems to detect multiple/unmergable points and _then_ operate sequentially - which is a mix of uncertainty and complexity high enough to warrant the warning in my opinion.
Happy to remove the warning if anyone is confident in how shapely is merging lines.